### PR TITLE
update: 将updatedAt,createdAt字段的time属性设置为true

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -39,10 +39,12 @@ module.exports = (app, url, opts) => {
                 if (properties.createdAt === undefined)
                     properties.createdAt = {};
                 properties.createdAt.type = 'date';
+                properties.createdAt.time = true; //change the field type to datetime in MySQL
 
                 if (properties.updatedAt === undefined)
                     properties.updatedAt = {};
                 properties.updatedAt.type = 'date';
+                properties.updatedAt.time = true; //change the field type to datetime in MySQL
 
                 var m = _define.call(this, name, properties, opts);
                 m.cid = cls_id++;


### PR DESCRIPTION
将updatedAt,createdAt字段的time属性设置为true，使得MySQL下这两个字段的类型由date为datetime，更符合业务场景。