### PR TITLE
Support Use Original Request in model's `functions`

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -1,13 +1,13 @@
 const mq = require('mq');
 const classes = require('./classes');
-const Db = require('./db');
+const setupDb = require('./db');
 const diagram = require('./utils/diagram');
 
 class App extends mq.Routing {
     constructor(url, opts) {
         super();
 
-        this.db = Db(this, url, opts);
+        this.db = setupDb(this, url, opts);
         classes.bind(this);
         this.diagram = diagram;
     }

--- a/lib/classes/index.js
+++ b/lib/classes/index.js
@@ -58,7 +58,8 @@ exports.bind = (app) => {
 
             var _req = {
                 session: req.session,
-                query: req.query.toJSON()
+                query: req.query.toJSON(),
+                request: req
             };
 
             var where = _req.query.where;
@@ -106,8 +107,8 @@ exports.bind = (app) => {
     _extend.bind(_, app);
 
     app.post('/:classname/:func', (req, classname, func) => {
-        _(req, classname, (req, db, cls, data) => {
-            if (!check_acl(req.session, func, cls.ACL))
+        _(req, classname, (_req, db, cls, data) => {
+            if (!check_acl(_req.session, func, cls.ACL))
                 return err_info(4030001, {}, cls.cid);
 
             const f = cls.functions[func];
@@ -118,7 +119,7 @@ exports.bind = (app) => {
                 }, cls.cid);
 
             try {
-                return f(req, data);
+                return f(_req, data);
             } catch (e) {
                 console.error(e.stack);
                 return err_info(5000002, {

--- a/lib/db.js
+++ b/lib/db.js
@@ -20,7 +20,7 @@ module.exports = (app, url, opts) => {
             var _define = db.define;
             var cls_id = 1;
 
-            db.define = function (name, properties, opts) {
+            db.define = function (name, properties, orm_define_opts) {
                 var old_properties = properties;
 
                 if (use_uuid)
@@ -46,7 +46,7 @@ module.exports = (app, url, opts) => {
                 properties.updatedAt.type = 'date';
                 properties.updatedAt.time = true; //change the field type to datetime in MySQL
 
-                var m = _define.call(this, name, properties, opts);
+                var m = _define.call(this, name, properties, orm_define_opts);
                 m.cid = cls_id++;
 
                 Object.defineProperty(m, 'model_name', {
@@ -56,15 +56,15 @@ module.exports = (app, url, opts) => {
                 var _beforeCreate;
                 var _beforeSave;
 
-                if (opts !== undefined) {
-                    if (opts.hooks !== undefined) {
-                        _beforeCreate = opts.hooks.beforeCreate;
-                        _beforeSave = opts.hooks.beforeSave;
+                if (orm_define_opts !== undefined) {
+                    if (orm_define_opts.hooks !== undefined) {
+                        _beforeCreate = orm_define_opts.hooks.beforeCreate;
+                        _beforeSave = orm_define_opts.hooks.beforeSave;
                     }
 
-                    m.functions = opts.functions;
-                    m.ACL = opts.ACL;
-                    m.OACL = opts.OACL;
+                    m.functions = orm_define_opts.functions;
+                    m.ACL = orm_define_opts.ACL;
+                    m.OACL = orm_define_opts.OACL;
                 }
 
                 if (m.ACL === undefined)
@@ -112,13 +112,13 @@ module.exports = (app, url, opts) => {
                 m.extends = {};
 
                 var _hasOne = m.hasOne;
-                m.hasOne = function (name, model, opts) {
+                m.hasOne = function (name, model, orm_hasOne_opts) {
                     m.extends[name] = {
                         type: 'hasOne',
                         model: model
                     };
 
-                    if (opts !== undefined && opts.reversed)
+                    if (orm_hasOne_opts !== undefined && orm_hasOne_opts.reversed)
                         m.extends[name].reversed = true;
 
                     return _hasOne.apply(this, slice.call(arguments));

--- a/lib/utils/diagram.js
+++ b/lib/utils/diagram.js
@@ -1,6 +1,6 @@
-module.exports = function () {
-    var Viz = require('viz.js');
+var Viz = require('viz.js');
 
+module.exports = function () {
     var models = [];
     var exts = [];
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "fib-push": "^1.0.0",
     "fib-session": "^0.1.1",
-    "viz.js": "^1.8.0"
+    "viz.js": "1.8.0"
   }
 }

--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,5 @@
 * 重写用例，用例独立运行, uuid
+  - 修正 uuid 模式下, 关联模型用 id 关联时, 关联字段在 mysql 中分配长度过小的问题.
 
 * reverse 测试
   - hasOne 测试


### PR DESCRIPTION
modifications
-  support get request from fn in `functions` of model definition, jus like that

```javascript
var model = db.defind('some_entity', {
    foo: 'bar'
}, {
    functions: {
        getChildren (_req, data) {
                // the `_req.request` is the real original HttpRequest which invoke `getChildren`
                const request = _req.request
                ...
        }
    }
})
```

- do some changes about syntax&annotation to make code more readable
- add one todo to TODO.md : )